### PR TITLE
Specify solr:7.7.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,4 +14,3 @@ services:
     image: solr-test
     ports:
      - 8983:8983
-    command: solr-create -c vivocore -d /opt/vivocore

--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -1,3 +1,5 @@
-FROM solr
+FROM solr:7.7.1
 
 COPY ./vivocore /opt/vivocore
+
+CMD solr-create -c vivocore -d /opt/vivocore


### PR DESCRIPTION
Move 'solr-create' command into solr/Dockerfile

Resolves: https://github.com/vivo-community/vivo-docker2/issues/1

# Testing this PR

1. Configure your local VIVO in runtime.properties to connect to the MariaDB and Solr found in this project (vivo-docker2)
   ```
   VitroConnection.DataSource.url = jdbc:mysql://localhost/vitrodb
   VitroConnection.DataSource.username = vitrodbUsername
   VitroConnection.DataSource.password = vitrodbPassword
   ```
   ```
   vitro.local.solr.url = http://localhost:8983/solr/vivocore
   ```
1. Start VIVO
   - Notice errors due to inability to connect to Solr and DB
1. Start the containers in this project/PR
   ```
   $docker-compose build
   $docker-compose up
   ```
1. Restart VIVO
   - Notice success
1. Log into VIVO as admin
1. Load sample data
   - https://raw.githubusercontent.com/vivo-project/sample-data/master/sample-data.n3
   - Notice success
1. Verify data in Docker/Solr index
   - http://localhost:8983/solr/#/vivocore/query
1. Verify data in Docker/MariaDB
   ```
   $docker exec -it vitrodb /bin/bash
   $mysql -u root -p
      - Note: password: abc123
   $use vitrodb;
   $show tables;
   $select * from Prefixes;
   $select * from Quads;
   ```
