### PR TITLE
Depends on

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,7 @@ The example [docker-compose.yml](docker-compose.yml) is a typical installation f
 docker-compose up -d
 ```
  Will start this project.  Navigating to http://localhost:8080/vivo will then start this simple instance.
-
- If you get an error indicating that the database was not found, this could be due to a bug where the vivo instance is not waiting on the mariadb instance to initialize.  IF you have this error, try `docker-compose down; docker-compose up -d`.
-
-
+ 
 ## VIVO Development
 
 You can use these same containers to develop a local VIVO installation.  In this

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,9 @@ services:
   vivo:
     build:
       context: ./vivo
+    depends_on:
+      - solr
+      - mariadb
     volumes:
       - ./example-config:/usr/local/vivo/home/config
     ports:


### PR DESCRIPTION
The readme describes:  "If you get an error indicating that the database was not found, this could be due to a bug where the vivo instance is not waiting on the mariadb instance to initialize.  IF you have this error, try `docker-compose down; docker-compose up -d`."

This seems to be solved by adding a "depends_on" to the docker-compose.yml

This pull request adds that, and updates the readme since the bug is no longer present.

Reproduce this by 
docker-compose down
docker volume rm vivo-docker2_maria-data vivo-docker2_solr-data
git checkout depends_on
docker-compose up -d

Expected outcome is the system starts correctly the first time, and doesn't require a docker-compose down, then a second docker-compose up.