### PR TITLE
specifies which volumes to docker volume rm

### DIFF
--- a/dc-dev-test-down.sh
+++ b/dc-dev-test-down.sh
@@ -4,5 +4,5 @@ docker-compose down
 docker rmi vivo-docker2_vivo vivo-docker2_solr vivo-docker2_mariadb
 docker rmi solr mariadb tomcat
 docker volume ls
-docker volume prune
+docker volume rm vivo-docker2_maria-data vivo-docker2_solr-data
 docker volume ls


### PR DESCRIPTION
This is totally a quality-of-life commit & not something serious.

What is changes is:  Instead of removing all the non-running docker volumes on a computer, it only removes the two volumes named in the docker-compose.yml.  For example, I have a big database volume from another project that I prefer to not delete.

Maybe this change negatively affects someone else's workflow though??  I'm ok with you closing this PR without action.