### PR TITLE
Add docker for sprint-i18n branch testing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,5 @@
 version: '3'
 services:
-  mariadb:
-    environment:
-      - MYSQL_USER=vitrodbUsername
-      - MYSQL_PASSWORD=vitrodbPassword
-      - MYSQL_ROOT_PASSWORD=rootPassword
-      - MYSQL_ROOT_HOST=%
-      - TZ=America/Chicago
-    build:
-      context: ./mariadb
-    volumes:
-      - maria-data:/var/lib/mysql
-    ports:
-      - 3306:3306
-
   solr:
     build:
       context: ./solr
@@ -34,4 +20,3 @@ services:
 
 volumes:
   solr-data:
-  maria-data:

--- a/example-config/applicationSetup.n3
+++ b/example-config/applicationSetup.n3
@@ -3,7 +3,7 @@
 # This file specifies the structure of the Vitro application: which modules
 # are used, and what parameters they require.
 #
-# Most Vitro installations will not need to modify this file. 
+# Most Vitro installations will not need to modify this file.
 #
 # For most installations, only the settings in the runtime.properties file will
 # be changed.
@@ -15,24 +15,24 @@
 
 # ----------------------------
 #
-# Describe the application by its implementing class and by references to the 
+# Describe the application by its implementing class and by references to the
 # modules it uses.
-# 
+#
 
-:application 
+:application
     a   vitroWebapp:application.ApplicationImpl ,
         vitroWebapp:modules.Application ;
     :hasSearchEngine              :instrumentedSearchEngineWrapper ;
     :hasSearchIndexer             :basicSearchIndexer ;
     :hasImageProcessor            :iioImageProcessor ;
     :hasFileStorage               :ptiFileStorage ;
-    :hasContentTripleSource       :sdbContentTripleSource ;
+    :hasContentTripleSource       :tdbContentTripleSource ;
     :hasConfigurationTripleSource :tdbConfigurationTripleSource ;
     :hasTBoxReasonerModule        :jfactTBoxReasonerModule .
 
 # ----------------------------
 #
-# Image processor module: 
+# Image processor module:
 #
 
 :iioImageProcessor
@@ -41,25 +41,25 @@
 
 # ----------------------------
 #
-# File storage module: 
+# File storage module:
 #    The PairTree-inspired implementation is the only standard option.
 #    It requires no parameters.
 #
 
-:ptiFileStorage 
+:ptiFileStorage
     a   vitroWebapp:filestorage.impl.FileStorageImplWrapper ,
         vitroWebapp:modules.fileStorage.FileStorage .
-               
+
 # ----------------------------
 #
-# Search engine module: 
+# Search engine module:
 #    The Solr-based implementation is the only standard option, but it can be
-#    wrapped in an "instrumented" wrapper, which provides additional logging 
+#    wrapped in an "instrumented" wrapper, which provides additional logging
 #    and more rigorous life-cycle checking.
 #
 
-:instrumentedSearchEngineWrapper 
-    a   vitroWebapp:searchengine.InstrumentedSearchEngineWrapper , 
+:instrumentedSearchEngineWrapper
+    a   vitroWebapp:searchengine.InstrumentedSearchEngineWrapper ,
         vitroWebapp:modules.searchEngine.SearchEngine ;
     :wraps :solrSearchEngine .
 
@@ -69,8 +69,8 @@
 
 # ----------------------------
 #
-# Search indexer module: 
-#    There is only one standard implementation. You must specify the number of 
+# Search indexer module:
+#    There is only one standard implementation. You must specify the number of
 #    worker threads in the thread pool.
 #
 
@@ -78,14 +78,14 @@
     a   vitroWebapp:searchindex.SearchIndexerImpl ,
         vitroWebapp:modules.searchIndexer.SearchIndexer ;
     :threadPoolSize "10" .
-    
+
 # ----------------------------
 #
 # Content triples source module: holds data contents
 #    The SDB-based implementation is the default option. It reads its parameters
 #    from the runtime.properties file, for backward compatibility.
 #
-#    Other implementations are based on a local TDB instance, a "standard" SPARQL 
+#    Other implementations are based on a local TDB instance, a "standard" SPARQL
 #    endpoint, or a Virtuoso endpoint, with parameters as shown.
 #
 
@@ -93,18 +93,18 @@
     a   vitroWebapp:triplesource.impl.sdb.ContentTripleSourceSDB ,
         vitroWebapp:modules.tripleSource.ContentTripleSource .
 
-#:tdbContentTripleSource
-#    a   vitroWebapp:triplesource.impl.tdb.ContentTripleSourceTDB ,
-#        vitroWebapp:modules.tripleSource.ContentTripleSource ;
-#    # May be an absolute path, or relative to the Vitro home directory.
-#    :hasTdbDirectory "tdbContentModels" .
+:tdbContentTripleSource
+    a   vitroWebapp:triplesource.impl.tdb.ContentTripleSourceTDB ,
+        vitroWebapp:modules.tripleSource.ContentTripleSource ;
+    # May be an absolute path, or relative to the Vitro home directory.
+    :hasTdbDirectory "tdbContentModels" .
 
 #:sparqlContentTripleSource
 #    a   vitroWebapp:triplesource.impl.sparql.ContentTripleSourceSPARQL ,
 #        vitroWebapp:modules.tripleSource.ContentTripleSource ;
 #    # The URI of the SPARQL endpoint for your triple-store.
 #    :hasEndpointURI "PUT_YOUR_SPARQL_ENDPOINT_URI_HERE" ;
-#    # The URI to use for SPARQL UPDATE calls against your triple-store. 
+#    # The URI to use for SPARQL UPDATE calls against your triple-store.
 #    :hasUpdateEndpointURI "PUT_THE UPDATE_URI_HERE" .
 
 #:virtuosoContentTripleSource
@@ -127,10 +127,10 @@
 :tdbConfigurationTripleSource
     a   vitroWebapp:triplesource.impl.tdb.ConfigurationTripleSourceTDB ,
         vitroWebapp:modules.tripleSource.ConfigurationTripleSource .
-        
+
 # ----------------------------
 #
-# TBox reasoner module: 
+# TBox reasoner module:
 #    The JFact-based implementation is the only standard option.
 #    It requires no parameters.
 #

--- a/mariadb/Dockerfile
+++ b/mariadb/Dockerfile
@@ -1,3 +1,0 @@
-FROM mariadb:10.4
-
-COPY ./mysql-init.sql /docker-entrypoint-initdb.d

--- a/mariadb/mysql-init.sql
+++ b/mariadb/mysql-init.sql
@@ -1,6 +1,0 @@
-CREATE DATABASE vitrodb CHARACTER SET utf8;
-GRANT ALL PRIVILEGES ON vitrodb.* TO 'vitrodbUsername'@'%' IDENTIFIED BY 'vitrodbPassword';
-GRANT ALL PRIVILEGES ON vitrodb.* TO 'vitrodbUsername'@'localhost' IDENTIFIED BY 'vitrodbPassword';
-FLUSH PRIVILEGES;
-
-

--- a/solr/vivocore/conf/solrconfig.xml
+++ b/solr/vivocore/conf/solrconfig.xml
@@ -758,7 +758,7 @@
              any query time fq params the user may specify, as a mechanism for
              partitioning the index, independent of any user selected filtering
              that may also be desired (perhaps as a result of faceted searching).
-    
+
              NOTE: there is *absolutely* nothing a client can do to prevent these
              "appends" values from being used, so don't use this mechanism
              unless you are sure you always want it.
@@ -772,14 +772,14 @@
              the options available to Solr clients.  Any params values
              specified here are used regardless of what values may be specified
              in either the query, the "defaults", or the "appends" params.
-    
+
              In this example, the facet.field and facet.query params would
              be fixed, limiting the facets clients can use.  Faceting is
              not turned on by default - but if the client does specify
              facet=true in the request, these are the only facets they
              will be able to see counts for; regardless of what other
              facet.field or facet.query params they may specify.
-    
+
              NOTE: there is *absolutely* nothing a client can do to prevent these
              "invariants" values from being used, so don't use this mechanism
              unless you are sure you always want it.
@@ -804,7 +804,7 @@
           -->
         </requestHandler>
 
- 
+
   <!-- A Robust Example
 
        This example SearchHandler declaration shows off usage of the
@@ -903,6 +903,33 @@
      </arr>
   </requestHandler>
 
+  <!-- Update Request Handler.
+      http://wiki.apache.org/solr/UpdateXmlMessages
+      The canonical Request Handler for Modifying the Index through
+      commands specified using XML, JSON, CSV, or JAVABIN
+      Note: Since solr1.1 requestHandlers requires a valid content
+      type header if posted in the body. For example, curl now
+      requires: -H 'Content-type:text/xml; charset=utf-8'
+      To override the request content type and force a specific
+      Content-type, use the request parameter:
+        ?update.contentType=text/csv
+      This handler will pick a response format to match the input
+      if the 'wt' parameter is not explicit
+   -->
+ <requestHandler name="/update" class="solr.UpdateRequestHandler">
+   <!-- See below for information on defining
+        updateRequestProcessorChains that can be used by name
+        on each Update Request
+     -->
+     <lst name="defaults">
+        <str name="update.chain">etag</str>
+      </lst>
+   <!--
+      <lst name="defaults">
+        <str name="update.chain">dedupe</str>
+      </lst>
+      -->
+ </requestHandler>
 
   <initParams path="/update/**,/query,/select,/tvrh,/elevate,/spell,/browse,update">
     <lst name="defaults">
@@ -1476,6 +1503,21 @@
       <processor class="solr.RunUpdateProcessorFactory" />
     </updateRequestProcessorChain>
   -->
+
+  <!-- ETag generation
+     Creates the "etag" field on the fly based on a hash of all other
+     fields.
+  -->
+   <updateRequestProcessorChain name="etag">
+     <processor class="solr.processor.SignatureUpdateProcessorFactory">
+       <bool name="enabled">true</bool>
+       <str name="signatureField">etag</str>
+       <bool name="overwriteDupes">false</bool>
+       <str name="signatureClass">solr.processor.Lookup3Signature</str>
+     </processor>
+     <processor class="solr.LogUpdateProcessorFactory" />
+     <processor class="solr.RunUpdateProcessorFactory" />
+   </updateRequestProcessorChain>
 
   <!-- Response Writers
 

--- a/vivo/Dockerfile
+++ b/vivo/Dockerfile
@@ -9,22 +9,30 @@ RUN apt-get install -y maven git
 
 WORKDIR /usr/local/
 
-#RUN git clone https://github.com/vivo-project/Vitro.git Vitro -b rel-1.11.0-RC
-#RUN git clone https://github.com/vivo-project/VIVO.git VIVO -b rel-1.11.0-RC
+RUN git clone https://github.com/vivo-project/Vitro.git Vitro 
+RUN git clone https://github.com/vivo-project/VIVO.git VIVO -b sprint-i18n
+RUN git clone https://github.com/vivo-project/VIVO-languages.git VIVO-languages 
+RUN git clone https://github.com/vivo-project/Vitro-languages.git Vitro-languages 
 
-ENV VITRO_VERSION 1.11.0
-RUN wget -O Vitro.zip https://github.com/vivo-project/Vitro/releases/download/vitro-${VITRO_VERSION}/vitro-${VITRO_VERSION}.zip 
-RUN unzip Vitro.zip -d Vitro
-RUN rm Vitro.zip
+ENV BRANCH_NAME docker
 
-ENV VIVO_VERSION 1.11.0
-RUN wget -O VIVO.zip https://github.com/vivo-project/VIVO/releases/download/vivo-${VIVO_VERSION}/VIVO-${VIVO_VERSION}.zip
-RUN unzip VIVO.zip -d VIVO
-RUN rm VIVO.zip
+WORKDIR /usr/local/Vitro/
+RUN git fetch origin pull/169/head:${BRANCH_NAME}
+RUN git checkout ${BRANCH_NAME}
+
+WORKDIR /usr/local/VIVO-languages/
+RUN git fetch origin pull/57/head:${BRANCH_NAME}
+RUN git checkout ${BRANCH_NAME}
+RUN mvn clean install
+
+WORKDIR /usr/local/Vitro-languages/
+RUN git fetch origin pull/24/head:${BRANCH_NAME}
+RUN git checkout ${BRANCH_NAME}
+RUN mvn clean install
 
 WORKDIR /usr/local/VIVO/
 COPY ./example-settings.xml example-settings.xml
-RUN mvn install -s example-settings.xml
+RUN mvn clean install -s example-settings.xml
 
 # clean up
 RUN rm -r /usr/local/tomcat/webapps/docs

--- a/vivo/Dockerfile
+++ b/vivo/Dockerfile
@@ -9,25 +9,17 @@ RUN apt-get install -y maven git
 
 WORKDIR /usr/local/
 
-RUN git clone https://github.com/vivo-project/Vitro.git Vitro 
+RUN git clone https://github.com/vivo-project/Vitro.git Vitro -b sprint-i18n
 RUN git clone https://github.com/vivo-project/VIVO.git VIVO -b sprint-i18n
-RUN git clone https://github.com/vivo-project/VIVO-languages.git VIVO-languages 
-RUN git clone https://github.com/vivo-project/Vitro-languages.git Vitro-languages 
+RUN git clone https://github.com/vivo-project/VIVO-languages.git VIVO-languages -b sprint-i18n
+RUN git clone https://github.com/vivo-project/Vitro-languages.git Vitro-languages -b sprint-i18n
 
 ENV BRANCH_NAME docker
 
-WORKDIR /usr/local/Vitro/
-RUN git fetch origin pull/169/head:${BRANCH_NAME}
-RUN git checkout ${BRANCH_NAME}
-
 WORKDIR /usr/local/VIVO-languages/
-RUN git fetch origin pull/57/head:${BRANCH_NAME}
-RUN git checkout ${BRANCH_NAME}
 RUN mvn clean install
 
 WORKDIR /usr/local/Vitro-languages/
-RUN git fetch origin pull/24/head:${BRANCH_NAME}
-RUN git checkout ${BRANCH_NAME}
 RUN mvn clean install
 
 WORKDIR /usr/local/VIVO/
@@ -46,8 +38,6 @@ WORKDIR /usr/local/VIVO/home/config
 
 COPY ./dockercompose.runtime.properties runtime.properties
 COPY ./example.applicationSetup.n3 applicationSetup.n3
-#COPY ./dockercompose.runtime.properties /usr/local/vivo/home/config/runtime.properties
-#COPY ./example.applicationSetup.n3 /usr/local/vivo/home/config/applicationSetup.n3
 
 RUN chmod ugo+w -R /usr/local/tomcat/temp
 RUN chmod ugo+w -R /usr/local/VIVO/home

--- a/vivo/dockercompose.runtime.properties
+++ b/vivo/dockercompose.runtime.properties
@@ -70,8 +70,8 @@ VitroConnection.DataSource.password = vitrodbPassword
   # the "Contact Us" form will be disabled and users will not be notified of
   # changes to their accounts.
   #
-email.smtpHost = smtp.mydomain.edu
-email.replyTo = vivoAdmin@mydomain.edu
+email.smtpHost = 
+email.replyTo = 
 
   # 
   # URL of Solr context used in local VIVO search. This will usually consist of:
@@ -187,7 +187,7 @@ VitroConnection.DataSource.validationQuery = SELECT 1
   # Show only the most appropriate data values based on the Accept-Language 
   # header supplied by the browser.  Default is false if not set.
   #
-# RDFService.languageFilter = false
+RDFService.languageFilter = true
 
   #
   # Force VIVO to use a specific language or Locale instead of those 

--- a/vivo/dockercompose.runtime.properties
+++ b/vivo/dockercompose.runtime.properties
@@ -61,28 +61,31 @@ argon2.time = 1000
   # URL to reflect your database name (if it is not "vitrodb"). Change the username 
   # and password to match the authorized database user you created.
   #
-VitroConnection.DataSource.url = jdbc:mysql://mariadb:3306/vitrodb
-VitroConnection.DataSource.username = vitrodbUsername
-VitroConnection.DataSource.password = vitrodbPassword
+# VitroConnection.DataSource.url = jdbc:mysql://mariadb:3306/vitrodb
+# VitroConnection.DataSource.username = vitrodbUsername
+# VitroConnection.DataSource.password = vitrodbPassword
 
   #
-  # Email parameters which VIVO can use to send mail. If these are left empty, 
+  # Email parameters which VIVO can use to send mail. If these are left empty,
   # the "Contact Us" form will be disabled and users will not be notified of
   # changes to their accounts.
-  #
-email.smtpHost = 
-email.replyTo = 
-
-  # 
-  # URL of Solr context used in local VIVO search. This will usually consist of:
-  #     scheme + server_name + port + vivo_webapp_name + "solr"
-  # In the standard installation, the Solr context will be on the same server as VIVO,
-  # and in the same Tomcat instance. The path will be the VIVO webapp.name (specified
-  # in build.properties) + "solr"
   #   Example:
-  #     vitro.local.solr.url = http://localhost:8080/vivosolr
+  #     email.smtpHost = smtp.mydomain.edu
+  #     email.replyTo = vivoAdmin@mydomain.edu
   #
-vitro.local.solr.url = http://solr:8983/solr/vivocore
+email.smtpHost =
+email.replyTo =
+
+  #
+  # URL of Solr context used in local VIVO search. This will usually consist of:
+  #     scheme + server_name + port + "solr" + solr_core_name
+  # In a standard Solr installation, the Solr service will be available on port
+  # 8983. The path will be /solr followed by the name used when adding a core
+  # for VIVO.
+  #   Example:
+  #     vitro.local.solr.url = http://localhost:8983/solr/vivocore
+  #
+vitro.local.solr.url = http://localhost:8983/solr/vivocore
 
 
 # -----------------------------------------------------------------------------
@@ -118,14 +121,14 @@ selfEditing.idMatchingProperty = http://vivo.mydomain.edu/ns#networkId
   # The maximum number of active connections in the database connection pool.
   # Increase this value to support a greater number of concurrent page requests.
   #
-VitroConnection.DataSource.pool.maxActive = 40
+# VitroConnection.DataSource.pool.maxActive = 40
 
   #
   # The maximum number of database connections that will be allowed
   # to remain idle in the connection pool.  Default is 25%
   # of the maximum number of active connections.
   #
-VitroConnection.DataSource.pool.maxIdle = 10
+# VitroConnection.DataSource.pool.maxIdle = 10
 
 
 # -----------------------------------------------------------------------------
@@ -136,9 +139,9 @@ VitroConnection.DataSource.pool.maxIdle = 10
   # Parameters to change in order to use VIVO with a database other than 
   # MySQL.
   #
-VitroConnection.DataSource.dbtype = MySQL
-VitroConnection.DataSource.driver = com.mysql.jdbc.Driver
-VitroConnection.DataSource.validationQuery = SELECT 1
+# VitroConnection.DataSource.dbtype = MySQL
+# VitroConnection.DataSource.driver = com.mysql.jdbc.Driver
+# VitroConnection.DataSource.validationQuery = SELECT 1
 
   # Note: the above parameters allow you to change the relational database that 
   # is used as the back end for Jena SDB. If you want to use a triple store 
@@ -207,28 +210,51 @@ RDFService.languageFilter = true
   #
   # This should not be used with languages.forceLocale, which will override it.
   #
-# languages.selectableLocales = en_US, es_GO
+languages.selectableLocales = en_US, es, de_DE, fr_CA
 
 
 # -----------------------------------------------------------------------------
 # ORCID INTEGRATION
 # -----------------------------------------------------------------------------
 
+  # The Client ID from your ORCID credentials
+  # When your application for credentials is accepted, you will receive a Client
+  # ID to be used in communications with the API. If you apply for sandbox
+  # credentials first, and then production credentials, you will likely receive
+  # two different Client IDs.
 # orcid.clientId = 0000-0000-0000-000X
+
+  # The Client Secret from your ORCID credentials
+  # When your application for credentials is accepted, you will receive a Client
+  # Secret to be used in communications with the API. If you apply for sandbox
+  # credentials first, and then production credentials, you will likely receive
+  # two different Client Secrets.
 # orcid.clientPassword = 00000000-0000-0000-0000-000000000000
-  
-   #
-   # The orcid.webappBaseUrl must end in a front slash (/)
-   # if it includes a path past the domain and (if required) port.
-   #
+
+  # The base URL for your VIVO application, as seen from outside.
+  # VIVO will use this to construct a callback URL that the ORCID API can use to
+  # return control to VIVO. The actual callback URL will be the string you
+  # provide here with the suffix of /orcid/callback added at the end.
+  # The orcid.webappBaseUrl must end in a front slash (/)
+  # if it includes a path past the domain and (if required) port.
+  #
 # orcid.webappBaseUrl = http://vivo.mydomain.edu/vivo/
 # orcid.externalIdCommonName = VIVO Cornell Identifier
 
-   # 1.2, 2.0
+  # The version of ORCIDs API protocol that VIVO will expect. Currently, the
+  # only supported version is 2.0.
 # orcid.apiVersion = 2.0
 
-   # release, sandbox
+  # The entry point for ORCID's public API.
+  # This changes, depending on whether you are using the sandbox API or the
+  # production API. Value is either release or sandbox.
 # orcid.api = sandbox
+
+  # Specify the type of API access that you have - public or member
+  #   public - only allows you to confirm ORCID IDs
+  #   member - allows VIVO to write a link to the VIVO profile in the ORCID record
+  # If you only have a public API key, ensure that you have entered public here
+#orcid.apiLevel = public
 
 # -----------------------------------------------------------------------------
 # OTHER OPTIONS
@@ -374,3 +400,15 @@ Vitro.reconcile.defaultTypeList = http://vivoweb.org/ontology/core#Role, core:Ro
     http://xmlns.com/foaf/0.1/Organization, foaf:Organization; \
     http://xmlns.com/foaf/0.1/Person, foaf:Person; \
     http://purl.obolibrary.org/obo/IAO_0000030, obo:IAO_0000030
+
+  # Configure the support for claiming by DOI or PMID
+  # This is a list of all the providers that are active for claiming articles from
+  # Options: doi, pmid
+  # which search Crossref and PubMed, respectively
+  # If you do not wish to use the claiming interface, set this property to nothing (empty)
+createAndLink.providers = doi, pmid
+
+  # Triple pattern fragments is a very fast, very simple means for querying a triple store.
+  # The triple pattern fragments API in VIVO puts little load on the server, providing a simple means for getting data from the triple store. The API has a web interface for manual use, can be used from the command line via curl, and can be used by programs.
+  #
+# tpf.activeFlag = true

--- a/vivo/dockercompose.runtime.properties
+++ b/vivo/dockercompose.runtime.properties
@@ -85,7 +85,7 @@ email.replyTo =
   #   Example:
   #     vitro.local.solr.url = http://localhost:8983/solr/vivocore
   #
-vitro.local.solr.url = http://localhost:8983/solr/vivocore
+vitro.local.solr.url = http://solr:8983/solr/vivocore
 
 
 # -----------------------------------------------------------------------------

--- a/vivo/example.applicationSetup.n3
+++ b/vivo/example.applicationSetup.n3
@@ -3,7 +3,7 @@
 # This file specifies the structure of the Vitro application: which modules
 # are used, and what parameters they require.
 #
-# Most Vitro installations will not need to modify this file. 
+# Most Vitro installations will not need to modify this file.
 #
 # For most installations, only the settings in the runtime.properties file will
 # be changed.
@@ -15,24 +15,24 @@
 
 # ----------------------------
 #
-# Describe the application by its implementing class and by references to the 
+# Describe the application by its implementing class and by references to the
 # modules it uses.
-# 
+#
 
-:application 
+:application
     a   vitroWebapp:application.ApplicationImpl ,
         vitroWebapp:modules.Application ;
     :hasSearchEngine              :instrumentedSearchEngineWrapper ;
     :hasSearchIndexer             :basicSearchIndexer ;
     :hasImageProcessor            :iioImageProcessor ;
     :hasFileStorage               :ptiFileStorage ;
-    :hasContentTripleSource       :sdbContentTripleSource ;
+    :hasContentTripleSource       :tdbContentTripleSource ;
     :hasConfigurationTripleSource :tdbConfigurationTripleSource ;
     :hasTBoxReasonerModule        :jfactTBoxReasonerModule .
 
 # ----------------------------
 #
-# Image processor module: 
+# Image processor module:
 #
 
 :iioImageProcessor
@@ -41,25 +41,25 @@
 
 # ----------------------------
 #
-# File storage module: 
+# File storage module:
 #    The PairTree-inspired implementation is the only standard option.
 #    It requires no parameters.
 #
 
-:ptiFileStorage 
+:ptiFileStorage
     a   vitroWebapp:filestorage.impl.FileStorageImplWrapper ,
         vitroWebapp:modules.fileStorage.FileStorage .
-               
+
 # ----------------------------
 #
-# Search engine module: 
+# Search engine module:
 #    The Solr-based implementation is the only standard option, but it can be
-#    wrapped in an "instrumented" wrapper, which provides additional logging 
+#    wrapped in an "instrumented" wrapper, which provides additional logging
 #    and more rigorous life-cycle checking.
 #
 
-:instrumentedSearchEngineWrapper 
-    a   vitroWebapp:searchengine.InstrumentedSearchEngineWrapper , 
+:instrumentedSearchEngineWrapper
+    a   vitroWebapp:searchengine.InstrumentedSearchEngineWrapper ,
         vitroWebapp:modules.searchEngine.SearchEngine ;
     :wraps :solrSearchEngine .
 
@@ -69,8 +69,8 @@
 
 # ----------------------------
 #
-# Search indexer module: 
-#    There is only one standard implementation. You must specify the number of 
+# Search indexer module:
+#    There is only one standard implementation. You must specify the number of
 #    worker threads in the thread pool.
 #
 
@@ -78,14 +78,14 @@
     a   vitroWebapp:searchindex.SearchIndexerImpl ,
         vitroWebapp:modules.searchIndexer.SearchIndexer ;
     :threadPoolSize "10" .
-    
+
 # ----------------------------
 #
 # Content triples source module: holds data contents
 #    The SDB-based implementation is the default option. It reads its parameters
 #    from the runtime.properties file, for backward compatibility.
 #
-#    Other implementations are based on a local TDB instance, a "standard" SPARQL 
+#    Other implementations are based on a local TDB instance, a "standard" SPARQL
 #    endpoint, or a Virtuoso endpoint, with parameters as shown.
 #
 
@@ -93,18 +93,18 @@
     a   vitroWebapp:triplesource.impl.sdb.ContentTripleSourceSDB ,
         vitroWebapp:modules.tripleSource.ContentTripleSource .
 
-#:tdbContentTripleSource
-#    a   vitroWebapp:triplesource.impl.tdb.ContentTripleSourceTDB ,
-#        vitroWebapp:modules.tripleSource.ContentTripleSource ;
-#    # May be an absolute path, or relative to the Vitro home directory.
-#    :hasTdbDirectory "tdbContentModels" .
+:tdbContentTripleSource
+    a   vitroWebapp:triplesource.impl.tdb.ContentTripleSourceTDB ,
+        vitroWebapp:modules.tripleSource.ContentTripleSource ;
+    # May be an absolute path, or relative to the Vitro home directory.
+    :hasTdbDirectory "tdbContentModels" .
 
 #:sparqlContentTripleSource
 #    a   vitroWebapp:triplesource.impl.sparql.ContentTripleSourceSPARQL ,
 #        vitroWebapp:modules.tripleSource.ContentTripleSource ;
 #    # The URI of the SPARQL endpoint for your triple-store.
 #    :hasEndpointURI "PUT_YOUR_SPARQL_ENDPOINT_URI_HERE" ;
-#    # The URI to use for SPARQL UPDATE calls against your triple-store. 
+#    # The URI to use for SPARQL UPDATE calls against your triple-store.
 #    :hasUpdateEndpointURI "PUT_THE UPDATE_URI_HERE" .
 
 #:virtuosoContentTripleSource
@@ -127,10 +127,10 @@
 :tdbConfigurationTripleSource
     a   vitroWebapp:triplesource.impl.tdb.ConfigurationTripleSourceTDB ,
         vitroWebapp:modules.tripleSource.ConfigurationTripleSource .
-        
+
 # ----------------------------
 #
-# TBox reasoner module: 
+# TBox reasoner module:
 #    The JFact-based implementation is the only standard option.
 #    It requires no parameters.
 #


### PR DESCRIPTION
Points repos to sprint-i18n branches for testing. Note, uses a TDB database instead of SDB.

Note, if you have already built VIVO using docker, you may want to blow away your caches before recomposing. 
`$ docker-compose up -d --build --force-recreate --renew-anon-volumes`