### PR TITLE
Add CATALINA_OPTS as part of entrypoint script

### DIFF
--- a/vivo/Dockerfile
+++ b/vivo/Dockerfile
@@ -43,5 +43,3 @@ COPY ./example.applicationSetup.n3 applicationSetup.n3
 
 RUN chmod ugo+w -R /usr/local/tomcat/temp
 RUN chmod ugo+w -R /usr/local/VIVO/home
-
-RUN export CATALINA_OPTS="-Xms512m -Xmx512m -XX:MaxPermSize=128m"

--- a/vivo/Dockerfile
+++ b/vivo/Dockerfile
@@ -43,3 +43,7 @@ COPY ./example.applicationSetup.n3 applicationSetup.n3
 
 RUN chmod ugo+w -R /usr/local/tomcat/temp
 RUN chmod ugo+w -R /usr/local/VIVO/home
+RUN ln -sf /dev/stdout /usr/local/tomcat/logs/vivo.all.log
+
+ADD start.sh /
+RUN chmod +x /start.sh

--- a/vivo/start.sh
+++ b/vivo/start.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+ln -s /usr/local/VIVO/webapps/vivo ROOT
+echo "export CATALINA_OPTS="'"-Xms8192m -Xmx8192m -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/VIVO"'"" > /usr/local/tomcat/bin/setenv.sh
+catalina.sh run


### PR DESCRIPTION
Issue: Since the CATALINA_OPTS was added part of the docker build it was not enforced when tomcat started up. This caused Java Heap space problems for VIVO.

Solution:Add CATALINA_OPTS as part of entrypoint script.
Also, added symlink for `vivo.all.log` to `/dev/stdout`. Added symlink for ROOT to vivo in webapps. This allows to remove the `/vivo` prefix for url.